### PR TITLE
Added binary for use from command-line.

### DIFF
--- a/bin/rusty_json
+++ b/bin/rusty_json
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+require "rusty_json"
+
+if $stdin.tty? && ARGV.empty?
+  puts "USAGE: $ echo '{\"test\":64}' | rusty_json"
+  puts "USAGE: $ rusty_json path/to/file.json"
+else
+  puts RustyJson.parse(ARGF.read)
+end

--- a/rusty_json.gemspec
+++ b/rusty_json.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = ["rusty_json"] # spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
Added binary for use from command-line:

```
$ echo '{\"test\":64}' | rusty_json
$ rusty_json path/to/file.json
$ rusty_json path/to/file1.json path/to/file2.json …
```
